### PR TITLE
Remove stray 's' from test package manifests.

### DIFF
--- a/test_catkin_virtualenv/package.xml
+++ b/test_catkin_virtualenv/package.xml
@@ -38,4 +38,4 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     <pip_requirements>requirements.txt</pip_requirements>
   </export>
 
-s</package>
+</package>

--- a/test_catkin_virtualenv_py3/package.xml
+++ b/test_catkin_virtualenv_py3/package.xml
@@ -39,4 +39,4 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
     <pip_requirements>requirements.txt</pip_requirements>
   </export>
 
-s</package>
+</package>


### PR DESCRIPTION
As per subject.

I would really have expected this to be more of a problem, but I didn't really get any complaints from `catkin`.
