### PR TITLE
Skip combining requirements files

### DIFF
--- a/catkin_virtualenv/cmake/combine_requirements.py
+++ b/catkin_virtualenv/cmake/combine_requirements.py
@@ -29,6 +29,11 @@ comment_regex = re.compile('\s*#.*')
 
 
 def combine_requirements(requirements_list, output_file):
+    if len(requirements_list) == 1:
+        # skip combining
+        output_file.write(requirements_list[0].read())
+        return
+
     # type: (List[IO], IO) -> int
     combined_requirements = {}  # type: Dict[str, requirements.Requirement]
     for requirements_file in requirements_list:


### PR DESCRIPTION
Related to #12 

## Why?

It is difficult to merge 2 requirements files if they have complex version specification or pip options.
So skipping the merge seems a good idea if we have only one requirements file.