### PR TITLE
add extra_pip_args

### DIFF
--- a/catkin_virtualenv/cmake/build_venv.py
+++ b/catkin_virtualenv/cmake/build_venv.py
@@ -50,6 +50,8 @@ if __name__ == '__main__':
         '--python-version', default=2, help="Build the virtualenv with which python major version.")
     parser.add_argument(
         '--use-system-packages', action="store_true", help="Use system site packages.")
+    parser.add_argument(
+        '--extra-pip-args', default='"-qq"', type=str, help="Extra pip args for install.")
 
     args, unknown = parser.parse_known_args()
 
@@ -69,7 +71,7 @@ if __name__ == '__main__':
         pip_version="10.0.1",
         use_system_packages=args.use_system_packages,
         python=python_executable,
-        extra_pip_arg=['-qq'],
+        extra_pip_arg=args.extra_pip_args[1:-1].split(' '),
         log_file=None,
         # TODO(pbovbel) Builtin venv (python3-venv) is not available on trusty. This flag can be re-enabled when
         # trusty support is dropped.

--- a/catkin_virtualenv/cmake/catkin_generate_virtualenv.cmake
+++ b/catkin_virtualenv/cmake/catkin_generate_virtualenv.cmake
@@ -18,6 +18,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 function(catkin_generate_virtualenv)
   set(oneValueArgs PYTHON_VERSION_MAJOR USE_SYSTEM_PACKAGES ISOLATE_REQUIREMENTS)
+  set(multiValueArgs EXTRA_PIP_ARGS)
   cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
   # Check if this package already has a virtualenv target before creating one
@@ -37,6 +38,11 @@ function(catkin_generate_virtualenv)
   if(NOT DEFINED ARG_ISOLATE_REQUIREMENTS)
     set(ARG_ISOLATE_REQUIREMENTS FALSE)
   endif()
+
+  if (NOT DEFINED ARG_EXTRA_PIP_ARGS)
+    set(ARG_EXTRA_PIP_ARGS "-qq")
+  endif()
+  string(REPLACE ";" "\ " extra_pip_args "${ARG_EXTRA_PIP_ARGS}")
 
   set(venv_dir venv)
 
@@ -84,14 +90,14 @@ function(catkin_generate_virtualenv)
 
   # Generate a virtualenv, fixing up paths for devel-space
   add_custom_command(OUTPUT ${venv_devel_dir}
-    COMMAND ${CATKIN_ENV} ${PYTHON_EXECUTABLE} ${catkin_virtualenv_CMAKE_DIR}/build_venv.py --root-dir ${venv_devel_dir} --requirements ${generated_requirements} --python-version ${ARG_PYTHON_VERSION_MAJOR} ${venv_args}
+    COMMAND ${CATKIN_ENV} ${PYTHON_EXECUTABLE} ${catkin_virtualenv_CMAKE_DIR}/build_venv.py --root-dir ${venv_devel_dir} --requirements ${generated_requirements} --python-version ${ARG_PYTHON_VERSION_MAJOR} ${venv_args} --extra-pip-args \\\"${extra_pip_args}\\\"
     WORKING_DIRECTORY ${venv_devel_dir}/..
     DEPENDS ${generated_requirements}
   )
 
   # Generate a virtualenv, fixing up paths for install-space
   add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/${venv_dir}
-    COMMAND ${CATKIN_ENV} ${PYTHON_EXECUTABLE} ${catkin_virtualenv_CMAKE_DIR}/build_venv.py --root-dir ${venv_install_dir} --requirements ${generated_requirements} --python-version ${ARG_PYTHON_VERSION_MAJOR} ${venv_args}
+    COMMAND ${CATKIN_ENV} ${PYTHON_EXECUTABLE} ${catkin_virtualenv_CMAKE_DIR}/build_venv.py --root-dir ${venv_install_dir} --requirements ${generated_requirements} --python-version ${ARG_PYTHON_VERSION_MAJOR} ${venv_args} --extra-pip-args \\\"${extra_pip_args}\\\"
     DEPENDS ${generated_requirements}
   )
 


### PR DESCRIPTION
- add `--extra-pip-args` and `EXTRA_PIP_ARGS` in `catkin_generate_virtualenv`

the reason I need this change is that I want to set `--no-binary=:all:` or `-vvv` instead of `-qq`.

ref: https://github.com/spotify/dh-virtualenv/issues/150