### PR TITLE
Don't inherit requirements from exec_depends

### DIFF
--- a/catkin_virtualenv/scripts/glob_requirements
+++ b/catkin_virtualenv/scripts/glob_requirements
@@ -65,7 +65,7 @@ def process_package(package_name, soft_fail=True):
             return [], []
     else:
         package = parse_package(package_path)
-        dependencies = package.build_depends + package.exec_depends + package.test_depends
+        dependencies = package.build_depends + package.test_depends
         return parse_exported_requirements(package), dependencies
 
 


### PR DESCRIPTION
In principle, an exec_depends package shouldn't be there at build time, so inheriting requirements from it makes no sense.

In practice, inheriting requirements via exec_depends breaks cases where launch and runtime components of packages interfere.