### PR TITLE
catkin-pkg-modules has disappeared off pypi

### DIFF
--- a/catkin_virtualenv/cmake/common_requirements.txt
+++ b/catkin_virtualenv/cmake/common_requirements.txt
@@ -1,3 +1,3 @@
-catkin-pkg
-nose
-rospkg
+catkin-pkg==0.4.13
+nose==1.3.7
+rospkg==1.1.10

--- a/catkin_virtualenv/cmake/common_requirements.txt
+++ b/catkin_virtualenv/cmake/common_requirements.txt
@@ -1,3 +1,3 @@
-catkin-pkg-modules
+catkin-pkg
 nose
 rospkg


### PR DESCRIPTION
catkin-pkg is still available, let's use that instead.

Short of chasing this upstream, I feel that somebody decided `-modules` packages are a construct invented to support debs and doesn't belong on pypi.