### PR TITLE
Rename process to program name

### DIFF
--- a/catkin_virtualenv/cmake/templates/program.devel.in
+++ b/catkin_virtualenv/cmake/templates/program.devel.in
@@ -1,2 +1,5 @@
 #!/usr/bin/env bash
-exec ${${PROJECT_NAME}_VENV_DEVEL_DIR}/bin/python ${program_path} "$@"
+node_name="$(echo "$@" | sed 's/.*__name:=\([^ ]*\).*/\1/')"
+name_prefix="$([ -v node_name ] && echo "-a $node_name")"
+exec $name_prefix ${${PROJECT_NAME}_VENV_DEVEL_DIR}/bin/python \
+    ${program_path} "$@"

--- a/catkin_virtualenv/cmake/templates/program.devel.in
+++ b/catkin_virtualenv/cmake/templates/program.devel.in
@@ -4,12 +4,6 @@ import sys
 
 from setproctitle import setproctitle
 
-PREFIX = "__name:="
-
-for arg in sys.argv:
-    if arg.startswith(PREFIX):
-        node_name = arg[len(PREFIX):]
-        setproctitle(' '.join([node_name] + sys.argv[1:]))
-        break
-
-exec(open("${program_path}").read())
+program_path = "${program_path}"
+setproctitle(' '.join([program_path] + sys.argv[1:]))
+exec(open(program_path).read())

--- a/catkin_virtualenv/cmake/templates/program.devel.in
+++ b/catkin_virtualenv/cmake/templates/program.devel.in
@@ -1,5 +1,15 @@
-#!/usr/bin/env bash
-node_name="$(echo "$@" | sed 's/.*__name:=\([^ ]*\).*/\1/')"
-name_prefix="$([ -v node_name ] && echo "-a $node_name")"
-exec $name_prefix ${${PROJECT_NAME}_VENV_DEVEL_DIR}/bin/python \
-    ${program_path} "$@"
+#!${${PROJECT_NAME}_VENV_DEVEL_DIR}/bin/python
+import re
+import sys
+
+from setproctitle import setproctitle
+
+PREFIX = "__name:="
+
+for arg in sys.argv:
+    if arg.startswith(PREFIX):
+        node_name = arg[len(PREFIX):]
+        setproctitle(' '.join([node_name] + sys.argv[1:]))
+        break
+
+exec(open("${program_path}").read())

--- a/catkin_virtualenv/cmake/templates/program.devel.in
+++ b/catkin_virtualenv/cmake/templates/program.devel.in
@@ -1,4 +1,6 @@
-#!${${PROJECT_NAME}_VENV_DEVEL_DIR}/bin/python
+#!/usr/bin/env bash
+
+exec ${${PROJECT_NAME}_VENV_DEVEL_DIR}/bin/python - "$@" <<EOF
 import re
 import sys
 
@@ -7,3 +9,4 @@ from setproctitle import setproctitle
 program_path = "${program_path}"
 setproctitle(' '.join([program_path] + sys.argv[1:]))
 exec(open(program_path).read())
+EOF

--- a/catkin_virtualenv/cmake/templates/program.install.in
+++ b/catkin_virtualenv/cmake/templates/program.install.in
@@ -4,12 +4,6 @@ import sys
 
 from setproctitle import setproctitle
 
-PREFIX = "__name:="
-
-for arg in sys.argv:
-    if arg.startswith(PREFIX):
-        node_name = arg[len(PREFIX):]
-        setproctitle(' '.join([node_name] + sys.argv[1:]))
-        break
-
-exec(open("${CMAKE_INSTALL_PREFIX}/${program_install_location}/${program_basename}").read())
+program_path = "${CMAKE_INSTALL_PREFIX}/${program_install_location}/${program_basename}"
+setproctitle(' '.join([program_path] + sys.argv[1:]))
+exec(open(program_path).read())

--- a/catkin_virtualenv/cmake/templates/program.install.in
+++ b/catkin_virtualenv/cmake/templates/program.install.in
@@ -1,5 +1,15 @@
-#!/usr/bin/env bash
-node_name="$(echo "$@" | sed 's/.*__name:=\([^ ]*\).*/\1/')"
-name_prefix="$([ -v node_name ] && echo "-a $node_name")"
-exec $name_prefix ${${PROJECT_NAME}_VENV_INSTALL_DIR}/bin/python \
-    ${CMAKE_INSTALL_PREFIX}/${program_install_location}/${program_basename} "$@"
+#!${${PROJECT_NAME}_VENV_INSTALL_DIR}/bin/python
+import re
+import sys
+
+from setproctitle import setproctitle
+
+PREFIX = "__name:="
+
+for arg in sys.argv:
+    if arg.startswith(PREFIX):
+        node_name = arg[len(PREFIX):]
+        setproctitle(' '.join([node_name] + sys.argv[1:]))
+        break
+
+exec(open("${CMAKE_INSTALL_PREFIX}/${program_install_location}/${program_basename}").read())

--- a/catkin_virtualenv/cmake/templates/program.install.in
+++ b/catkin_virtualenv/cmake/templates/program.install.in
@@ -1,2 +1,5 @@
 #!/usr/bin/env bash
-exec ${${PROJECT_NAME}_VENV_INSTALL_DIR}/bin/python ${CMAKE_INSTALL_PREFIX}/${program_install_location}/${program_basename} "$@"
+node_name="$(echo "$@" | sed 's/.*__name:=\([^ ]*\).*/\1/')"
+name_prefix="$([ -v node_name ] && echo "-a $node_name")"
+exec $name_prefix ${${PROJECT_NAME}_VENV_INSTALL_DIR}/bin/python \
+    ${CMAKE_INSTALL_PREFIX}/${program_install_location}/${program_basename} "$@"

--- a/catkin_virtualenv/cmake/templates/program.install.in
+++ b/catkin_virtualenv/cmake/templates/program.install.in
@@ -1,4 +1,6 @@
-#!${${PROJECT_NAME}_VENV_INSTALL_DIR}/bin/python
+#!/usr/bin/env bash
+
+exec ${${PROJECT_NAME}_VENV_INSTALL_DIR}/bin/python - "$@" <<EOF
 import re
 import sys
 
@@ -7,3 +9,4 @@ from setproctitle import setproctitle
 program_path = "${CMAKE_INSTALL_PREFIX}/${program_install_location}/${program_basename}"
 setproctitle(' '.join([program_path] + sys.argv[1:]))
 exec(open(program_path).read())
+EOF

--- a/catkin_virtualenv/requirements.in
+++ b/catkin_virtualenv/requirements.in
@@ -1,3 +1,4 @@
 catkin-pkg
 nose
-rospkg>=1.3.0
+rospkg
+setproctitle

--- a/catkin_virtualenv/requirements.txt
+++ b/catkin_virtualenv/requirements.txt
@@ -4,12 +4,13 @@
 #
 #    pip-compile
 #
-catkin-pkg==0.4.23
-distro==1.5.0             # via rospkg
-docutils==0.16            # via catkin-pkg
-nose==1.3.7
-pyparsing==2.4.7          # via catkin-pkg
-python-dateutil==2.8.1    # via catkin-pkg
-pyyaml==5.4.1             # via rospkg
-rospkg==1.3.0
-six==1.15.0               # via python-dateutil
+catkin-pkg==0.4.24        # via -r requirements.in, rospkg
+distro==1.7.0             # via rospkg
+docutils==0.18.1          # via catkin-pkg
+nose==1.3.7               # via -r requirements.in
+pyparsing==3.0.8          # via catkin-pkg
+python-dateutil==2.8.2    # via catkin-pkg
+pyyaml==6.0               # via rospkg
+rospkg==1.4.0             # via -r requirements.in
+setproctitle==1.2.2       # via -r requirements.in
+six==1.16.0               # via python-dateutil


### PR DESCRIPTION
~https://github.com/locusrobotics/catkin_virtualenv/pull/51 works fine, but changing the process name seems to bork something about how the virtualenv is loaded (see test results).~

Replaced bash exec with python magic, this makes python process names very similar to native processes for monitoring purposes.