### PR TITLE
Upgrade pip to avoid cache permission failure

### DIFF
--- a/catkin_virtualenv/scripts/build_venv
+++ b/catkin_virtualenv/scripts/build_venv
@@ -89,7 +89,7 @@ if __name__ == '__main__':
         log_file=None,
         builtin_venv=check_module(python_executable, 'venv'),
         builtin_pip=check_module(python_executable, 'pip'),
-        pip_version='19.3.1'  # (pbovbel) known working version
+        pip_version='20.0.2'  # (pbovbel) known working version
     )
 
     while True:


### PR DESCRIPTION
I faced build failure due to a permission problem while building a package using catkin_virtualenv:
```
  WARNING: Building wheel for gdown failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/a5'
ERROR: Could not build wheels for gdown which use PEP 517 and cannot be installed directly
```
This is because my pip cache directory (`/home/pazeshun/.cache/pip`) belongs to root as I installed pip by `sudo apt install python-pip` and usually use `sudo pip install`.
This problem was already reported to pip repo (https://github.com/pypa/pip/issues/7488) and fixed from pip 20.0 (https://github.com/pypa/pip/pull/7489), so I want catkin_virtualenv to use pip 20.0.

## How to reproduce my problem
I prepared https://github.com/pazeshun/test_catkin_venv_gdown and https://gist.github.com/pazeshun/f716674ab9220c67cf4b75c84ef456e2 to reproduce my problem:
```
$ mkdir -p ~/ros/repro_venv_fail/src
$ cd ~/ros/repro_venv_fail/src/
$ wstool init
Writing /home/pazeshun/ros/repro_venv_fail/src/.rosinstall

update complete.
$ wstool merge https://gist.githubusercontent.com/pazeshun/f716674ab9220c67cf4b75c84ef456e2/raw/10f46a49085bfd6f71bbcf810b8c315e49e70ada/reproduce_venv_failure.rosinstall
     Performing actions: 

     Add new elements:
  catkin_virtualenv,  test_catkin_venv_gdown

Config changed, maybe you need run wstool update to update SCM entries.
Overwriting /home/pazeshun/ros/repro_venv_fail/src/.rosinstall

update complete.
$ wstool update
[catkin_virtualenv] Fetching https://github.com/locusrobotics/catkin_virtualenv (version 0.5.2) to /home/pazeshun/ros/repro_venv_fail/src/catkin_virtualenv
Cloning into '/home/pazeshun/ros/repro_venv_fail/src/catkin_virtualenv'...
remote: Enumerating objects: 119, done.
remote: Counting objects: 100% (119/119), done.
remote: Compressing objects: 100% (83/83), done.
remote: Total 1067 (delta 63), reused 67 (delta 36), pack-reused 948
Receiving objects: 100% (1067/1067), 168.46 KiB | 0 bytes/s, done.
Resolving deltas: 100% (740/740), done.
Checking connectivity... done.
[catkin_virtualenv] Done.
[test_catkin_venv_gdown] Fetching https://github.com/pazeshun/test_catkin_venv_gdown (version None) to /home/pazeshun/ros/repro_venv_fail/src/test_catkin_venv_gdown
Cloning into '/home/pazeshun/ros/repro_venv_fail/src/test_catkin_venv_gdown'...
remote: Enumerating objects: 5, done.
remote: Counting objects: 100% (5/5), done.
remote: Compressing objects: 100% (4/4), done.
remote: Total 5 (delta 0), reused 5 (delta 0), pack-reused 0
Unpacking objects: 100% (5/5), done.
Checking connectivity... done.
[test_catkin_venv_gdown] Done.
$ cd ..
$ catkin build test_catkin_venv_gdown
---------------------------------------------------------------------------------
Profile:                     default
Extending:             [env] /home/pazeshun/ros/ws_jsk_apc/devel:/opt/ros/kinetic
Workspace:                   /home/pazeshun/ros/repro_venv_fail
---------------------------------------------------------------------------------
Build Space:        [exists] /home/pazeshun/ros/repro_venv_fail/build
Devel Space:        [exists] /home/pazeshun/ros/repro_venv_fail/devel
Install Space:      [unused] /home/pazeshun/ros/repro_venv_fail/install
Log Space:         [missing] /home/pazeshun/ros/repro_venv_fail/logs
Source Space:       [exists] /home/pazeshun/ros/repro_venv_fail/src
DESTDIR:            [unused] None
---------------------------------------------------------------------------------
Devel Space Layout:          linked
Install Space Layout:        None
---------------------------------------------------------------------------------
Additional CMake Args:       None
Additional Make Args:        None
Additional catkin Make Args: None
Internal Make Job Server:    True
Cache Job Environments:      False
---------------------------------------------------------------------------------
Whitelisted Packages:        None
Blacklisted Packages:        None
---------------------------------------------------------------------------------
Workspace configuration appears valid.

NOTE: Forcing CMake to run for each package.
---------------------------------------------------------------------------------
[build] Found '6' packages in 0.0 seconds.                                                                                          
[build] Updating package table.                                                                                                     
Starting  >>> catkin_tools_prebuild                                                                                                 
Finished  <<< catkin_tools_prebuild                 [ 1.7 seconds ]                                                                 
Starting  >>> catkin_virtualenv                                                                                                     
Finished  <<< catkin_virtualenv                     [ 2.1 seconds ]                                                                 
Starting  >>> test_catkin_venv_gdown                                                                                                
____________________________________________________________________________________________________________________________________
Errors     << test_catkin_venv_gdown:make /home/pazeshun/ros/repro_venv_fail/logs/test_catkin_venv_gdown/build.make.000.log         
/home/pazeshun/ros/repro_venv_fail/build/test_catkin_venv_gdown/venv/local/lib/python2.7/site-packages/pip/_vendor/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.
  warnings.warn(warning, RequestsDependencyWarning)
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
WARNING: The directory '/home/pazeshun/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
/home/pazeshun/ros/repro_venv_fail/build/test_catkin_venv_gdown/venv/local/lib/python2.7/site-packages/pip/_vendor/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.
  warnings.warn(warning, RequestsDependencyWarning)
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
WARNING: The directory '/home/pazeshun/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
WARNING: The directory '/home/pazeshun/.cache/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
/home/pazeshun/ros/repro_venv_fail/devel/.private/test_catkin_venv_gdown/share/test_catkin_venv_gdown/venv/local/lib/python2.7/site-packages/pip/_vendor/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.
  warnings.warn(warning, RequestsDependencyWarning)
WARNING: You are using pip version 19.3.1; however, version 20.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
WARNING: The directory '/home/pazeshun/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
/home/pazeshun/ros/repro_venv_fail/build/test_catkin_venv_gdown/venv/local/lib/python2.7/site-packages/pip/_vendor/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.
  warnings.warn(warning, RequestsDependencyWarning)
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
WARNING: The directory '/home/pazeshun/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
WARNING: The directory '/home/pazeshun/.cache/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
/home/pazeshun/ros/repro_venv_fail/devel/.private/test_catkin_venv_gdown/share/test_catkin_venv_gdown/venv/local/lib/python2.7/site-packages/pip/_vendor/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.
  warnings.warn(warning, RequestsDependencyWarning)
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
WARNING: The directory '/home/pazeshun/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
WARNING: The directory '/home/pazeshun/.cache/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
WARNING: You are using pip version 19.3.1; however, version 20.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
/home/pazeshun/ros/repro_venv_fail/devel/.private/test_catkin_venv_gdown/share/test_catkin_venv_gdown/venv/local/lib/python2.7/site-packages/pip/_vendor/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.
  warnings.warn(warning, RequestsDependencyWarning)
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
WARNING: The directory '/home/pazeshun/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
WARNING: The directory '/home/pazeshun/.cache/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
  WARNING: Building wheel for gdown failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/a5'
  WARNING: Building wheel for rospkg failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/2c'
  WARNING: Building wheel for catkin-pkg failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/bf'
  WARNING: Building wheel for PyYAML failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/a7'
  WARNING: Building wheel for filelock failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/66'
ERROR: Could not build wheels for gdown which use PEP 517 and cannot be installed directly
WARNING: You are using pip version 19.3.1; however, version 20.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Error, clearing virtualenv and retrying: Command '['/home/pazeshun/ros/repro_venv_fail/build/test_catkin_venv_gdown/venv/bin/python', '-m', 'pip', 'install', '--force-reinstall', '-r', '/home/pazeshun/ros/repro_venv_fail/build/test_catkin_venv_gdown/generated_requirements.txt']' returned non-zero exit status 1
/home/pazeshun/ros/repro_venv_fail/build/test_catkin_venv_gdown/venv/local/lib/python2.7/site-packages/pip/_vendor/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.
  warnings.warn(warning, RequestsDependencyWarning)
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
WARNING: The directory '/home/pazeshun/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
  WARNING: Building wheel for gdown failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/a5'
  WARNING: Building wheel for rospkg failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/2c'
  WARNING: Building wheel for catkin-pkg failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/bf'
  WARNING: Building wheel for PyYAML failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/a7'
  WARNING: Building wheel for filelock failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/66'
ERROR: Could not build wheels for gdown which use PEP 517 and cannot be installed directly
WARNING: You are using pip version 19.3.1; however, version 20.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Error, clearing virtualenv and retrying: Command '['/home/pazeshun/ros/repro_venv_fail/devel/.private/test_catkin_venv_gdown/share/test_catkin_venv_gdown/venv/bin/python', '-m', 'pip', 'install', '--force-reinstall', '-r', '/home/pazeshun/ros/repro_venv_fail/build/test_catkin_venv_gdown/generated_requirements.txt']' returned non-zero exit status 1
/home/pazeshun/ros/repro_venv_fail/build/test_catkin_venv_gdown/venv/local/lib/python2.7/site-packages/pip/_vendor/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.
  warnings.warn(warning, RequestsDependencyWarning)
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
WARNING: The directory '/home/pazeshun/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
WARNING: The directory '/home/pazeshun/.cache/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
/home/pazeshun/ros/repro_venv_fail/devel/.private/test_catkin_venv_gdown/share/test_catkin_venv_gdown/venv/local/lib/python2.7/site-packages/pip/_vendor/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.
  warnings.warn(warning, RequestsDependencyWarning)
WARNING: You are using pip version 19.3.1; however, version 20.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
WARNING: The directory '/home/pazeshun/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
/home/pazeshun/ros/repro_venv_fail/build/test_catkin_venv_gdown/venv/local/lib/python2.7/site-packages/pip/_vendor/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.
  warnings.warn(warning, RequestsDependencyWarning)
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
WARNING: The directory '/home/pazeshun/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
WARNING: The directory '/home/pazeshun/.cache/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
/home/pazeshun/ros/repro_venv_fail/devel/.private/test_catkin_venv_gdown/share/test_catkin_venv_gdown/venv/local/lib/python2.7/site-packages/pip/_vendor/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.
  warnings.warn(warning, RequestsDependencyWarning)
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
WARNING: The directory '/home/pazeshun/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
WARNING: The directory '/home/pazeshun/.cache/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
WARNING: You are using pip version 19.3.1; however, version 20.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
/home/pazeshun/ros/repro_venv_fail/devel/.private/test_catkin_venv_gdown/share/test_catkin_venv_gdown/venv/local/lib/python2.7/site-packages/pip/_vendor/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.
  warnings.warn(warning, RequestsDependencyWarning)
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
WARNING: The directory '/home/pazeshun/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
WARNING: The directory '/home/pazeshun/.cache/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
  WARNING: Building wheel for gdown failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/a5'
  WARNING: Building wheel for rospkg failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/2c'
  WARNING: Building wheel for catkin-pkg failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/bf'
  WARNING: Building wheel for PyYAML failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/a7'
  WARNING: Building wheel for filelock failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/66'
ERROR: Could not build wheels for gdown which use PEP 517 and cannot be installed directly
WARNING: You are using pip version 19.3.1; however, version 20.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Error, clearing virtualenv and retrying: Command '['/home/pazeshun/ros/repro_venv_fail/build/test_catkin_venv_gdown/venv/bin/python', '-m', 'pip', 'install', '--force-reinstall', '-r', '/home/pazeshun/ros/repro_venv_fail/build/test_catkin_venv_gdown/generated_requirements.txt']' returned non-zero exit status 1
/home/pazeshun/ros/repro_venv_fail/build/test_catkin_venv_gdown/venv/local/lib/python2.7/site-packages/pip/_vendor/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.
  warnings.warn(warning, RequestsDependencyWarning)
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
WARNING: The directory '/home/pazeshun/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
  WARNING: Building wheel for gdown failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/a5'
  WARNING: Building wheel for rospkg failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/2c'
  WARNING: Building wheel for catkin-pkg failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/bf'
  WARNING: Building wheel for PyYAML failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/a7'
  WARNING: Building wheel for filelock failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/66'
ERROR: Could not build wheels for gdown which use PEP 517 and cannot be installed directly
WARNING: You are using pip version 19.3.1; however, version 20.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Error, clearing virtualenv and retrying: Command '['/home/pazeshun/ros/repro_venv_fail/devel/.private/test_catkin_venv_gdown/share/test_catkin_venv_gdown/venv/bin/python', '-m', 'pip', 'install', '--force-reinstall', '-r', '/home/pazeshun/ros/repro_venv_fail/build/test_catkin_venv_gdown/generated_requirements.txt']' returned non-zero exit status 1
/home/pazeshun/ros/repro_venv_fail/build/test_catkin_venv_gdown/venv/local/lib/python2.7/site-packages/pip/_vendor/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.
  warnings.warn(warning, RequestsDependencyWarning)
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
WARNING: The directory '/home/pazeshun/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
WARNING: The directory '/home/pazeshun/.cache/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
/home/pazeshun/ros/repro_venv_fail/devel/.private/test_catkin_venv_gdown/share/test_catkin_venv_gdown/venv/local/lib/python2.7/site-packages/pip/_vendor/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.
  warnings.warn(warning, RequestsDependencyWarning)
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
WARNING: The directory '/home/pazeshun/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
WARNING: You are using pip version 19.3.1; however, version 20.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
/home/pazeshun/ros/repro_venv_fail/build/test_catkin_venv_gdown/venv/local/lib/python2.7/site-packages/pip/_vendor/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.
  warnings.warn(warning, RequestsDependencyWarning)
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
WARNING: The directory '/home/pazeshun/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
WARNING: The directory '/home/pazeshun/.cache/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
/home/pazeshun/ros/repro_venv_fail/devel/.private/test_catkin_venv_gdown/share/test_catkin_venv_gdown/venv/local/lib/python2.7/site-packages/pip/_vendor/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.
  warnings.warn(warning, RequestsDependencyWarning)
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
WARNING: The directory '/home/pazeshun/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
WARNING: The directory '/home/pazeshun/.cache/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
WARNING: You are using pip version 19.3.1; however, version 20.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
/home/pazeshun/ros/repro_venv_fail/devel/.private/test_catkin_venv_gdown/share/test_catkin_venv_gdown/venv/local/lib/python2.7/site-packages/pip/_vendor/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.
  warnings.warn(warning, RequestsDependencyWarning)
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
WARNING: The directory '/home/pazeshun/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
WARNING: The directory '/home/pazeshun/.cache/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
  WARNING: Building wheel for gdown failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/a5'
  WARNING: Building wheel for rospkg failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/2c'
  WARNING: Building wheel for catkin-pkg failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/bf'
  WARNING: Building wheel for PyYAML failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/a7'
  WARNING: Building wheel for filelock failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/66'
ERROR: Could not build wheels for gdown which use PEP 517 and cannot be installed directly
WARNING: You are using pip version 19.3.1; however, version 20.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Error, clearing virtualenv and retrying: Command '['/home/pazeshun/ros/repro_venv_fail/build/test_catkin_venv_gdown/venv/bin/python', '-m', 'pip', 'install', '--force-reinstall', '-r', '/home/pazeshun/ros/repro_venv_fail/build/test_catkin_venv_gdown/generated_requirements.txt']' returned non-zero exit status 1
/home/pazeshun/ros/repro_venv_fail/build/test_catkin_venv_gdown/venv/local/lib/python2.7/site-packages/pip/_vendor/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.
  warnings.warn(warning, RequestsDependencyWarning)
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
WARNING: The directory '/home/pazeshun/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
  WARNING: Building wheel for gdown failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/a5'
  WARNING: Building wheel for rospkg failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/2c'
  WARNING: Building wheel for catkin-pkg failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/bf'
  WARNING: Building wheel for PyYAML failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/a7'
  WARNING: Building wheel for filelock failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/66'
ERROR: Could not build wheels for gdown which use PEP 517 and cannot be installed directly
WARNING: You are using pip version 19.3.1; however, version 20.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Error, clearing virtualenv and retrying: Command '['/home/pazeshun/ros/repro_venv_fail/devel/.private/test_catkin_venv_gdown/share/test_catkin_venv_gdown/venv/bin/python', '-m', 'pip', 'install', '--force-reinstall', '-r', '/home/pazeshun/ros/repro_venv_fail/build/test_catkin_venv_gdown/generated_requirements.txt']' returned non-zero exit status 1
/home/pazeshun/ros/repro_venv_fail/build/test_catkin_venv_gdown/venv/local/lib/python2.7/site-packages/pip/_vendor/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.
  warnings.warn(warning, RequestsDependencyWarning)
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
WARNING: The directory '/home/pazeshun/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
WARNING: The directory '/home/pazeshun/.cache/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
WARNING: You are using pip version 19.3.1; however, version 20.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
/home/pazeshun/ros/repro_venv_fail/devel/.private/test_catkin_venv_gdown/share/test_catkin_venv_gdown/venv/local/lib/python2.7/site-packages/pip/_vendor/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.
  warnings.warn(warning, RequestsDependencyWarning)
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
WARNING: The directory '/home/pazeshun/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
/home/pazeshun/ros/repro_venv_fail/build/test_catkin_venv_gdown/venv/local/lib/python2.7/site-packages/pip/_vendor/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.
  warnings.warn(warning, RequestsDependencyWarning)
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
WARNING: The directory '/home/pazeshun/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
WARNING: The directory '/home/pazeshun/.cache/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
/home/pazeshun/ros/repro_venv_fail/devel/.private/test_catkin_venv_gdown/share/test_catkin_venv_gdown/venv/local/lib/python2.7/site-packages/pip/_vendor/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.
  warnings.warn(warning, RequestsDependencyWarning)
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
WARNING: The directory '/home/pazeshun/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
WARNING: The directory '/home/pazeshun/.cache/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
WARNING: You are using pip version 19.3.1; however, version 20.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
/home/pazeshun/ros/repro_venv_fail/devel/.private/test_catkin_venv_gdown/share/test_catkin_venv_gdown/venv/local/lib/python2.7/site-packages/pip/_vendor/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.
  warnings.warn(warning, RequestsDependencyWarning)
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
WARNING: The directory '/home/pazeshun/.cache/pip/http' or its parent directory is not owned by the current user and the cache has been disabled. Please check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
WARNING: The directory '/home/pazeshun/.cache/pip' or its parent directory is not owned by the current user and caching wheels has been disabled. check the permissions and owner of that directory. If executing pip with sudo, you may want sudo's -H flag.
  WARNING: Building wheel for gdown failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/a5'
  WARNING: Building wheel for rospkg failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/2c'
  WARNING: Building wheel for catkin-pkg failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/bf'
  WARNING: Building wheel for PyYAML failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/a7'
  WARNING: Building wheel for filelock failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/66'
ERROR: Could not build wheels for gdown which use PEP 517 and cannot be installed directly
WARNING: You are using pip version 19.3.1; however, version 20.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Traceback (most recent call last):
  File "/home/pazeshun/ros/repro_venv_fail/src/catkin_virtualenv/catkin_virtualenv/scripts/build_venv", line 101, in <module>
    deploy.install_dependencies()
  File "/home/pazeshun/ros/repro_venv_fail/src/catkin_virtualenv/catkin_virtualenv/src/dh_virtualenv/deployment.py", line 191, in install_dependencies
    check_call(self.pip('-r', requirements_path))
  File "/home/pazeshun/ros/repro_venv_fail/src/catkin_virtualenv/catkin_virtualenv/src/dh_virtualenv/deployment.py", line 39, in check_call
    return subprocess.check_call(cmd, *args, **kwargs)
  File "/usr/lib/python2.7/subprocess.py", line 541, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/home/pazeshun/ros/repro_venv_fail/build/test_catkin_venv_gdown/venv/bin/python', '-m', 'pip', 'install', '--force-reinstall', '-r', '/home/pazeshun/ros/repro_venv_fail/build/test_catkin_venv_gdown/generated_requirements.txt']' returned non-zero exit status 1
make[2]: *** [venv] Error 1
make[2]: *** Waiting for unfinished jobs....
  WARNING: Building wheel for gdown failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/a5'
  WARNING: Building wheel for rospkg failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/2c'
  WARNING: Building wheel for catkin-pkg failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/bf'
  WARNING: Building wheel for PyYAML failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/a7'
  WARNING: Building wheel for filelock failed: [Errno 13] Permission denied: '/home/pazeshun/.cache/pip/wheels/66'
ERROR: Could not build wheels for gdown which use PEP 517 and cannot be installed directly
WARNING: You are using pip version 19.3.1; however, version 20.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
Traceback (most recent call last):
  File "/home/pazeshun/ros/repro_venv_fail/src/catkin_virtualenv/catkin_virtualenv/scripts/build_venv", line 101, in <module>
    deploy.install_dependencies()
  File "/home/pazeshun/ros/repro_venv_fail/src/catkin_virtualenv/catkin_virtualenv/src/dh_virtualenv/deployment.py", line 191, in install_dependencies
    check_call(self.pip('-r', requirements_path))
  File "/home/pazeshun/ros/repro_venv_fail/src/catkin_virtualenv/catkin_virtualenv/src/dh_virtualenv/deployment.py", line 39, in check_call
    return subprocess.check_call(cmd, *args, **kwargs)
  File "/usr/lib/python2.7/subprocess.py", line 541, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/home/pazeshun/ros/repro_venv_fail/devel/.private/test_catkin_venv_gdown/share/test_catkin_venv_gdown/venv/bin/python', '-m', 'pip', 'install', '--force-reinstall', '-r', '/home/pazeshun/ros/repro_venv_fail/build/test_catkin_venv_gdown/generated_requirements.txt']' returned non-zero exit status 1
make[2]: *** [/home/pazeshun/ros/repro_venv_fail/devel/.private/test_catkin_venv_gdown/share/test_catkin_venv_gdown/venv] Error 1
make[1]: *** [CMakeFiles/test_catkin_venv_gdown_generate_virtualenv.dir/all] Error 2
make: *** [all] Error 2
cd /home/pazeshun/ros/repro_venv_fail/build/test_catkin_venv_gdown; catkin build --get-env test_catkin_venv_gdown | catkin env -si  /usr/bin/make --jobserver-fds=6,7 -j; cd -
....................................................................................................................................
Failed     << test_catkin_venv_gdown:make           [ Exited with code 2 ]                                                          
Failed    <<< test_catkin_venv_gdown                [ 1 minute and 18.4 seconds ]                                                   
[build] Summary: 2 of 3 packages succeeded.                                                                                         
[build]   Ignored:   4 packages were skipped or are blacklisted.                                                                    
[build]   Warnings:  None.                                                                                                          
[build]   Abandoned: None.                                                                                                          
[build]   Failed:    1 packages failed.                                                                                             
[build] Runtime: 1 minute and 22.3 seconds total.                                                                                   
[build] Note: Workspace packages have changed, please re-source setup files to use them.
```