### PR TITLE
RST-3172 Check that requirements file is locked

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The following options are supported by `catkin_generate_virtualenv()`:
 
 ```cmake
 catkin_generate_virtualenv(
-  # Specify the package's set of input requirements to automatically lock
+  # Specify the input requirements for this package that catkin_virtualenv will automatically lock.
   INPUT_REQUIREMENTS requirements.in
 
   # Select an alternative python interpreter - it must be installed on the system.
@@ -125,6 +125,9 @@ catkin_generate_virtualenv(
 
   # Disable including pip requirements from catkin dependencies of this package.
   ISOLATE_REQUIREMENTS TRUE  # Default FALSE
+
+  # Disable creating a unit test to verify that package requirements are locked.
+  CHECK_VENV FALSE  # Default TRUE
 
   # Provide extra arguments to the underlying pip invocation
   EXTRA_PIP_ARGS

--- a/catkin_virtualenv/CMakeLists.txt
+++ b/catkin_virtualenv/CMakeLists.txt
@@ -15,6 +15,7 @@ install(DIRECTORY cmake
 set(python_scripts
   scripts/collect_requirements
   scripts/venv_init
+  scripts/venv_check
   scripts/venv_lock
   scripts/venv_install
   scripts/venv_relocate

--- a/catkin_virtualenv/cmake/catkin_generate_virtualenv.cmake
+++ b/catkin_virtualenv/cmake/catkin_generate_virtualenv.cmake
@@ -83,6 +83,13 @@ function(catkin_generate_virtualenv)
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
 
+  # Trigger rebuild if any of the requirements files change
+  foreach(requirements_file ${requirements_list})
+    if(EXISTS ${requirements_file})
+      stamp(${requirements_file})
+    endif()
+  endforeach()
+
   add_custom_command(COMMENT "Generate virtualenv in ${CMAKE_BINARY_DIR}/${venv_dir}"
     OUTPUT ${CMAKE_BINARY_DIR}/${venv_dir}/bin/python
     COMMAND ${CATKIN_ENV} rosrun catkin_virtualenv venv_init ${venv_dir}

--- a/catkin_virtualenv/cmake/catkin_generate_virtualenv.cmake
+++ b/catkin_virtualenv/cmake/catkin_generate_virtualenv.cmake
@@ -67,18 +67,19 @@ function(catkin_generate_virtualenv)
   set(${PROJECT_NAME}_VENV_DEVEL_DIR ${venv_devel_dir} PARENT_SCOPE)
   set(${PROJECT_NAME}_VENV_INSTALL_DIR ${venv_install_dir} PARENT_SCOPE)
 
-  # Collect requirements from each catkin package in the dependency chain
-  execute_process(
-    COMMAND ${CATKIN_ENV} rosrun catkin_virtualenv collect_requirements
-      --package-name ${PROJECT_NAME} ${lock_args}
-    OUTPUT_VARIABLE requirements_list
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
-
+  # Store just _this_ project's requirements file in ${package_requirements}
   execute_process(
     COMMAND ${CATKIN_ENV} rosrun catkin_virtualenv collect_requirements --no-deps
       --package-name ${PROJECT_NAME} ${lock_args}
     OUTPUT_VARIABLE package_requirements
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+
+  # Collect all of this project's inherited requirements into ${requirements_list}
+  execute_process(
+    COMMAND ${CATKIN_ENV} rosrun catkin_virtualenv collect_requirements
+      --package-name ${PROJECT_NAME} ${lock_args}
+    OUTPUT_VARIABLE requirements_list
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
 

--- a/catkin_virtualenv/cmake/catkin_generate_virtualenv.cmake
+++ b/catkin_virtualenv/cmake/catkin_generate_virtualenv.cmake
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 function(catkin_generate_virtualenv)
-  set(oneValueArgs PYTHON_VERSION PYTHON_INTERPRETER USE_SYSTEM_PACKAGES ISOLATE_REQUIREMENTS INPUT_REQUIREMENTS)
+  set(oneValueArgs PYTHON_VERSION PYTHON_INTERPRETER USE_SYSTEM_PACKAGES ISOLATE_REQUIREMENTS INPUT_REQUIREMENTS CHECK_VENV)
   set(multiValueArgs EXTRA_PIP_ARGS)
   cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN} )
 
@@ -98,10 +98,6 @@ function(catkin_generate_virtualenv)
         ${CMAKE_BINARY_DIR}/${venv_dir}/bin/python
         ${CMAKE_SOURCE_DIR}/${ARG_INPUT_REQUIREMENTS}
     )
-
-  elseif(NOT DEFINED ARG_INPUT_REQUIREMENTS AND NOT package_requirements STREQUAL "")
-    message(WARNING "Please define an INPUT_REQUIREMENTS block and generate a lock file - see https://github.com/locusrobotics/catkin_virtualenv/blob/master/README.md#locking-dependencies")
-
   endif()
 
   add_custom_command(COMMENT "Install requirements to ${CMAKE_BINARY_DIR}/${venv_dir}"
@@ -143,6 +139,17 @@ function(catkin_generate_virtualenv)
       ${venv_devel_dir}
       ${CMAKE_SOURCE_DIR}/${ARG_INPUT_REQUIREMENTS}
   )
+
+  if(NOT package_requirements STREQUAL "" AND (NOT DEFINED ARG_CHECK_VENV OR ARG_CHECK_VENV))
+    file(MAKE_DIRECTORY ${CATKIN_TEST_RESULTS_DIR}/${PROJECT_NAME})
+    catkin_run_tests_target("venv_check" "${PROJECT_NAME}-requirements" "venv_check-${PROJECT_NAME}-requirements.xml"
+      COMMAND "${CATKIN_ENV} rosrun catkin_virtualenv venv_check ${venv_dir} --requirements ${package_requirements} \
+        --extra-pip-args \"${processed_pip_args}\" \
+        --xunit-output ${CATKIN_TEST_RESULTS_DIR}/${PROJECT_NAME}/venv_check-${PROJECT_NAME}-requirements.xml"
+      DEPENDENCIES ${PROJECT_NAME}_generate_virtualenv
+      WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    )
+  endif()
 
   install(DIRECTORY ${CMAKE_BINARY_DIR}/install/${venv_dir}
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}

--- a/catkin_virtualenv/cmake/catkin_generate_virtualenv.cmake
+++ b/catkin_virtualenv/cmake/catkin_generate_virtualenv.cmake
@@ -132,7 +132,7 @@ function(catkin_generate_virtualenv)
   )
 
   add_custom_target(venv_lock
-    COMMENT "Manually invoked target to write out ${ARG_LOCK_FILE}"
+    COMMENT "Manually invoked target to generate the lock file on demand"
     COMMAND ${CATKIN_ENV} rosrun catkin_virtualenv venv_lock ${venv_dir}
       --package-name ${PROJECT_NAME} --input-requirements ${CMAKE_SOURCE_DIR}/${ARG_INPUT_REQUIREMENTS}
       --extra-pip-args ${processed_pip_args}
@@ -155,9 +155,6 @@ function(catkin_generate_virtualenv)
   install(DIRECTORY ${CMAKE_BINARY_DIR}/install/${venv_dir}
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
     USE_SOURCE_PERMISSIONS)
-
-  install(FILES ${ARG_LOCK_FILE}
-    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
 
   # (pbovbel): NOSETESTS originally set by catkin here:
   # <https://github.com/ros/catkin/blob/kinetic-devel/cmake/test/nosetests.cmake#L86>

--- a/catkin_virtualenv/package.xml
+++ b/catkin_virtualenv/package.xml
@@ -34,6 +34,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
   <build_export_depend>python-virtualenv</build_export_depend>
   <build_export_depend>python3-dev</build_export_depend>
   <build_export_depend>python3-nose</build_export_depend>
+  <build_export_depend>python3-rospkg-modules</build_export_depend>
   <build_export_depend>python3-venv</build_export_depend>
   <build_export_depend>rosbash</build_export_depend>
   <build_export_depend>virtualenv</build_export_depend>

--- a/catkin_virtualenv/scripts/collect_requirements
+++ b/catkin_virtualenv/scripts/collect_requirements
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Software License Agreement (GPL)
 #
 # \file      collect_requirements

--- a/catkin_virtualenv/scripts/venv_check
+++ b/catkin_virtualenv/scripts/venv_check
@@ -48,7 +48,7 @@ if __name__ == '__main__':
     venv = Virtualenv(args.venv)
     diff = venv.check(
         requirements=args.requirements,
-        extra_pip_args=extra_pip_args.split(' ') if extra_pip_args else [],
+        extra_pip_args=[arg for arg in extra_pip_args.split(" ") if arg != ""],
     )
 
     if args.xunit_output:

--- a/catkin_virtualenv/scripts/venv_check
+++ b/catkin_virtualenv/scripts/venv_check
@@ -33,7 +33,7 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(description=Virtualenv.install.__doc__)
     parser.add_argument(
-        'venv', help="Path of virtualenv to manage")
+        'venv', help="Path of virtualenv to manage.")
     parser.add_argument(
         '--requirements', required=True, help="Requirements to check.")
     parser.add_argument(

--- a/catkin_virtualenv/scripts/venv_check
+++ b/catkin_virtualenv/scripts/venv_check
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# Software License Agreement (GPL)
+#
+# \file      venv_install
+# \authors   Paul Bovbel <pbovbel@locusrobotics.com>
+# \copyright Copyright (c) (2017,), Locus Robotics, All rights reserved.
+#
+# This program is free software: you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation, either version 2 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+import argparse
+import inspect
+import sys
+
+import xml.etree.ElementTree as ET
+
+from catkin_virtualenv import configure_logging
+from catkin_virtualenv.venv import Virtualenv
+
+
+if __name__ == '__main__':
+    logger = configure_logging()
+
+    parser = argparse.ArgumentParser(description=Virtualenv.install.__doc__)
+    parser.add_argument(
+        'venv', help="Path of virtualenv to manage")
+    parser.add_argument(
+        '--requirements', required=True, help="Requirements to check.")
+    parser.add_argument(
+        '--extra-pip-args', default="\"\"", type=str, help="Extra pip args for install.")
+    parser.add_argument(
+        '--xunit-output', help="Destination where to write xunit output.")
+
+    args = parser.parse_args()
+
+    extra_pip_args = args.extra_pip_args[1:-1]
+
+    venv = Virtualenv(args.venv)
+    diff = venv.check(
+        requirements=args.requirements,
+        extra_pip_args=extra_pip_args.split(' ') if extra_pip_args else [],
+    )
+
+    if args.xunit_output:
+        testsuite = ET.Element('testsuite', name="venv_check", tests="1", failures="1" if diff else "0", errors="0")
+        testcase = ET.SubElement(testsuite, 'testcase', name="check_locked", classname="catkin_virtualenv.Venv")
+        if diff:
+            failure = ET.SubElement(testcase, 'failure', message="{} is not fully locked".format(args.requirements))
+            message = inspect.cleandoc("""
+            Consider defining INPUT_REQUIREMENTS to have catkin_virtualenv generate a lock file for this package.
+            See https://github.com/locusrobotics/catkin_virtualenv/blob/master/README.md#locking-dependencies.
+            The following changes would fully lock {requirements}:
+            """.format(requirements=args.requirements))
+            message += '\n' + '\n'.join(diff)
+            failure.text = message
+
+        else:
+            success = ET.SubElement(testcase, 'success', message="{} is fully locked".format(args.requirements))
+
+        tree = ET.ElementTree(testsuite)
+        tree.write(args.xunit_output, encoding='utf-8', xml_declaration=True)
+
+    else:
+        if diff:
+            logger.error("{} is not fully locked, see diff:\n{}".format(args.requirements, '\n'.join(diff)))
+            sys.exit(1)

--- a/catkin_virtualenv/scripts/venv_check
+++ b/catkin_virtualenv/scripts/venv_check
@@ -37,7 +37,7 @@ if __name__ == '__main__':
     parser.add_argument(
         '--requirements', required=True, help="Requirements to check.")
     parser.add_argument(
-        '--extra-pip-args', default="\"\"", type=str, help="Extra pip args for install.")
+        '--extra-pip-args', default='""', type=str, help="Extra pip args for install.")
     parser.add_argument(
         '--xunit-output', help="Destination where to write xunit output.")
 

--- a/catkin_virtualenv/scripts/venv_init
+++ b/catkin_virtualenv/scripts/venv_init
@@ -35,7 +35,7 @@ if __name__ == '__main__':
     parser.add_argument(
         '--use-system-packages', action="store_true", help="Use system site packages.")
     parser.add_argument(
-        '--extra-pip-args', default="\"\"", type=str, help="Extra pip args for install.")
+        '--extra-pip-args', default='""', type=str, help="Extra pip args for install.")
 
     args = parser.parse_args()
 

--- a/catkin_virtualenv/scripts/venv_init
+++ b/catkin_virtualenv/scripts/venv_init
@@ -46,5 +46,5 @@ if __name__ == '__main__':
     venv.initialize(
         python=args.python,
         use_system_packages=args.use_system_packages,
-        extra_pip_args=extra_pip_args.split(' ') if extra_pip_args else [],
+        extra_pip_args=[arg for arg in extra_pip_args.split(" ") if arg != ""],
     )

--- a/catkin_virtualenv/scripts/venv_init
+++ b/catkin_virtualenv/scripts/venv_init
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Software License Agreement (GPL)
 #
 # \file      venv_init

--- a/catkin_virtualenv/scripts/venv_install
+++ b/catkin_virtualenv/scripts/venv_install
@@ -29,7 +29,7 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(description=Virtualenv.install.__doc__)
     parser.add_argument(
-        'venv', help="Path of virtualenv to manage")
+        'venv', help="Path of virtualenv to manage.")
     parser.add_argument(
         '--requirements', required=True, nargs='+', help="Requirements to sync to virtualenv.")
     parser.add_argument(

--- a/catkin_virtualenv/scripts/venv_install
+++ b/catkin_virtualenv/scripts/venv_install
@@ -33,7 +33,7 @@ if __name__ == '__main__':
     parser.add_argument(
         '--requirements', required=True, nargs='+', help="Requirements to sync to virtualenv.")
     parser.add_argument(
-        '--extra-pip-args', default="\"\"", type=str, help="Extra pip args for install.")
+        '--extra-pip-args', default='""', type=str, help="Extra pip args for install.")
 
     args = parser.parse_args()
 

--- a/catkin_virtualenv/scripts/venv_install
+++ b/catkin_virtualenv/scripts/venv_install
@@ -42,5 +42,5 @@ if __name__ == '__main__':
     venv = Virtualenv(args.venv)
     venv.install(
         requirements=args.requirements,
-        extra_pip_args=extra_pip_args.split(' ') if extra_pip_args else [],
+        extra_pip_args=[arg for arg in extra_pip_args.split(" ") if arg != ""],
     )

--- a/catkin_virtualenv/scripts/venv_install
+++ b/catkin_virtualenv/scripts/venv_install
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Software License Agreement (GPL)
 #
 # \file      venv_install

--- a/catkin_virtualenv/scripts/venv_lock
+++ b/catkin_virtualenv/scripts/venv_lock
@@ -37,7 +37,7 @@ if __name__ == '__main__':
     parser.add_argument(
         '--no-overwrite', action="store_true", help="Don't overwrite lock file if it exists.")
     parser.add_argument(
-        '--extra-pip-args', default="\"\"", type=str, help="Extra pip args for install.")
+        '--extra-pip-args', default='""', type=str, help="Extra pip args for install.")
 
     args = parser.parse_args()
 

--- a/catkin_virtualenv/scripts/venv_lock
+++ b/catkin_virtualenv/scripts/venv_lock
@@ -48,5 +48,5 @@ if __name__ == '__main__':
         package_name=args.package_name,
         input_requirements=args.input_requirements,
         no_overwrite=args.no_overwrite,
-        extra_pip_args=extra_pip_args.split(' ') if extra_pip_args else [],
+        extra_pip_args=[arg for arg in extra_pip_args.split(" ") if arg != ""],
     )

--- a/catkin_virtualenv/scripts/venv_lock
+++ b/catkin_virtualenv/scripts/venv_lock
@@ -29,7 +29,7 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(description=Virtualenv.lock.__doc__)
     parser.add_argument(
-        'venv', help="Path of virtualenv to manage")
+        'venv', help="Path of virtualenv to manage.")
     parser.add_argument(
         '--package-name', required=True, help="Package name that virtualenv belongs to.")
     parser.add_argument(

--- a/catkin_virtualenv/scripts/venv_lock
+++ b/catkin_virtualenv/scripts/venv_lock
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Software License Agreement (GPL)
 #
 # \file      venv_init

--- a/catkin_virtualenv/scripts/venv_relocate
+++ b/catkin_virtualenv/scripts/venv_relocate
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Software License Agreement (GPL)
 #
 # \file      venv_relocate

--- a/catkin_virtualenv/src/catkin_virtualenv/__init__.py
+++ b/catkin_virtualenv/src/catkin_virtualenv/__init__.py
@@ -33,7 +33,12 @@ def configure_logging():
     except KeyError:
         logging.basicConfig()
 
+    return logging.getLogger()
 
-def check_call(cmd, *args, **kwargs):
+
+def run_command(cmd, *args, **kwargs):
     logger.info(' '.join(cmd))
-    return subprocess.check_call(cmd, *args, **kwargs)
+    if kwargs.pop('capture_output', False):
+        kwargs['stdout'] = subprocess.PIPE
+        kwargs['stderr'] = subprocess.PIPE
+    return subprocess.run(cmd, *args, **kwargs)

--- a/catkin_virtualenv/src/catkin_virtualenv/collect_requirements.py
+++ b/catkin_virtualenv/src/catkin_virtualenv/collect_requirements.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 
 import os
 
-from Queue import Queue
+from queue import Queue
 from catkin.find_in_workspaces import find_in_workspaces
 from catkin_pkg.package import parse_package
 

--- a/catkin_virtualenv/src/catkin_virtualenv/relocate.py
+++ b/catkin_virtualenv/src/catkin_virtualenv/relocate.py
@@ -22,7 +22,7 @@ import os
 import re
 import subprocess
 
-from . import check_call
+from . import run_command
 
 PYTHON_INTERPRETERS = ['python', 'pypy', 'ipy', 'jython']
 _PYTHON_INTERPRETERS_REGEX = r'\(' + r'\|'.join(PYTHON_INTERPRETERS) + r'\)'
@@ -35,8 +35,7 @@ def find_script_files(venv_dir):
         '-e', r'^#!.*bin/\(env \)\?{0}'.format(_PYTHON_INTERPRETERS_REGEX),
         '-e', r"^'''exec.*bin/{0}".format(_PYTHON_INTERPRETERS_REGEX),
         os.path.join(venv_dir, 'bin')]
-    grep_proc = subprocess.Popen(command, stdout=subprocess.PIPE)
-    files, _ = grep_proc.communicate()
+    files = run_command(command, check=True, capture_output=True).stdout
     return {f for f in files.decode('utf-8').strip().split('\n') if f}
 
 
@@ -50,7 +49,7 @@ def fix_shebangs(venv_dir, target_dir):
             r's-^#!.*bin/\(env \)\?{names}\"\?-#!{pythonpath}-;'
             r"s-^'''exec'.*bin/{names}-'''exec' {pythonpath}-"
         ).format(names=_PYTHON_INTERPRETERS_REGEX, pythonpath=re.escape(pythonpath))
-        check_call(['sed', '-i', regex, f])
+        run_command(['sed', '-i', regex, f], check=True)
 
 
 def fix_activate_path(venv_dir, target_dir):

--- a/catkin_virtualenv/src/catkin_virtualenv/venv.py
+++ b/catkin_virtualenv/src/catkin_virtualenv/venv.py
@@ -20,13 +20,12 @@
 from __future__ import print_function
 
 import difflib
-import os
 import logging
+import os
 import re
 import shutil
 import subprocess
 import tempfile
-import re
 
 from distutils.spawn import find_executable
 


### PR DESCRIPTION
From discussion with @abencz, we probably don't want to blindly recommend INPUT_REQUIREMENTS, and instead just ensure that requirements are actually locked.

This actually satisfies the spirit of the RST-3172 better, since we can detect any insufficiently locked requirements.

Sneaks in a python3 port of catkin_virtualenv proper.

- test is defined https://github.com/locusrobotics/catkin_virtualenv/pull/62/files#diff-a043275b2d398f3545b4e19805ea7cbaR144
- test 'main' script and xunit output https://github.com/locusrobotics/catkin_virtualenv/pull/62/files#diff-2c3f93cafacb2e82d2c8b0733c97fb29R31
- test logic https://github.com/locusrobotics/catkin_virtualenv/pull/62/files#diff-df9eea60531facde7a05b91c71e12841R96
