### PR TITLE
Make regex for Python bytecode more selective

### DIFF
--- a/catkin_virtualenv/src/catkin_virtualenv/venv.py
+++ b/catkin_virtualenv/src/catkin_virtualenv/venv.py
@@ -32,7 +32,7 @@ from distutils.spawn import find_executable
 from . import run_command, relocate
 from .collect_requirements import collect_requirements
 
-_BYTECODE_REGEX = re.compile('.*.py[co]')
+_BYTECODE_REGEX = re.compile('.*\.py[co]')
 _COMMENT_REGEX = re.compile('(^|\s+)#.*$', flags=re.MULTILINE)
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Fix regex to match only files ending in ".py[co]" and not files ending
in "py[co]".