### PR TITLE
Don't require catkin_package to be called before catkin_generate_virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,6 @@ In CMakeLists.txt:
 # Make sure to find-package `catkin_virtualenv`
 find_package(catkin REQUIRED ... catkin_virtualenv ...)
 
-# Must be called before catkin_generate_virtualenv
-catkin_package()
-
 # Generate the virtualenv
 catkin_generate_virtualenv()
 

--- a/catkin_virtualenv/cmake/catkin_generate_virtualenv.cmake
+++ b/catkin_virtualenv/cmake/catkin_generate_virtualenv.cmake
@@ -57,8 +57,10 @@ function(catkin_generate_virtualenv)
     return()
   endif()
 
-  ### Start building virtualenv
+  # Make sure CATKIN_* paths are initialized
+  catkin_destinations()
 
+  ### Start building virtualenv
   set(venv_dir venv)
 
   set(venv_devel_dir ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/${venv_dir})

--- a/catkin_virtualenv/cmake/catkin_generate_virtualenv.cmake
+++ b/catkin_virtualenv/cmake/catkin_generate_virtualenv.cmake
@@ -58,7 +58,7 @@ function(catkin_generate_virtualenv)
   endif()
 
   # Make sure CATKIN_* paths are initialized
-  catkin_destinations()
+  catkin_destinations()  # oh the places we'll go
 
   ### Start building virtualenv
   set(venv_dir venv)

--- a/test_catkin_virtualenv/CMakeLists.txt
+++ b/test_catkin_virtualenv/CMakeLists.txt
@@ -3,11 +3,12 @@ project(test_catkin_virtualenv)
 
 find_package(catkin REQUIRED COMPONENTS catkin_virtualenv)
 
-catkin_package()
-
 catkin_generate_virtualenv(
   INPUT_REQUIREMENTS requirements.in
 )
+
+# Order with catkin_generate_virtualenv shouldn't matter
+catkin_package()
 
 install(FILES requirements.txt
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})


### PR DESCRIPTION
Mitigate a common user error