### PR TITLE
Python2: always require a 44.x version of setuptools

### DIFF
--- a/catkin_virtualenv/src/catkin_virtualenv/venv.py
+++ b/catkin_virtualenv/src/catkin_virtualenv/venv.py
@@ -75,8 +75,9 @@ class Virtualenv:
                 '--verbose',
                 '--python', python
             ]
-            # py2's virtualenv command will try install latest setuptools. setuptools>=45 not compatible with py2
-            preinstall += ['setuptools<45']
+            # py2's virtualenv command will try install latest setuptools. setuptools>=45 not compatible with py2,
+            # but we do require a reasonably up-to-date version (because of pip==20.1), so v44 at least.
+            preinstall += ['setuptools>=44,<45']
 
         if use_system_packages:
             virtualenv.append('--system-site-packages')


### PR DESCRIPTION
The old version specification would also evaluate to true if `USE_SYSTEM_PACKAGES` was `TRUE` and the base OS already had a version of `setuptools` installed (which is often the case).

On Xenial fi this leads to `20.7.0` satisfying the `<45` requirement, but that version doesn't appear to be compatible with `pip==20.1`.

For context, see #70.
