### PR TITLE
bump rospkg>=1.3.0 for rosdep>=0.20.1

### DIFF
--- a/catkin_virtualenv/requirements.in
+++ b/catkin_virtualenv/requirements.in
@@ -1,3 +1,3 @@
 catkin-pkg
 nose
-rospkg
+rospkg>=1.3.0

--- a/catkin_virtualenv/requirements.txt
+++ b/catkin_virtualenv/requirements.txt
@@ -11,5 +11,5 @@ nose==1.3.7
 pyparsing==2.4.7          # via catkin-pkg
 python-dateutil==2.8.1    # via catkin-pkg
 pyyaml==5.4.1             # via rospkg
-rospkg==1.2.10
+rospkg==1.3.0
 six==1.15.0               # via python-dateutil


### PR DESCRIPTION
This PR fix `rospkg` version above `1.3.0`.
`rosdep>=0.20.1` requires `rospkg>=1.3.0`.
Therefore, I bump the version to `rospkg>=1.3.0`.

Related:
https://github.com/ros-infrastructure/rosdep/issues/807

