### PR TITLE
Set pip and pip-tools versions as minimal

### DIFF
--- a/catkin_virtualenv/src/catkin_virtualenv/venv.py
+++ b/catkin_virtualenv/src/catkin_virtualenv/venv.py
@@ -60,8 +60,8 @@ class Virtualenv:
             raise RuntimeError(error_msg)
 
         preinstall = [
-            "pip==20.1",
-            "pip-tools==5.1.2",
+            "pip>=20.1",
+            "pip-tools>=5.1.2",
         ]
 
         builtin_venv = self._check_module(system_python, "venv")


### PR DESCRIPTION
I'm testing on Ubuntu 22.04 with python 3.10. Using those exact python versions forces every single pip package to be built from sources. Allowing to install the latest versions makes it work as expected.