### PR TITLE
Make CMake work in non-isolated builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,9 @@ at build time. You should check both `requirements.in` and `requirements.txt` in
 
 To regenerate the `requirements.txt` file, either delete it and rebuild the project, or run this command from your project directory:
 
-`catkin build --this --no-deps --catkin-make-args venv_lock`
+`catkin build --this --no-deps --catkin-make-args <PROJECT_NAME>_venv_lock` where `<PROJECT_NAME>` is the name for the project as specified in the package's CMakeLists.txt.
+
+Alternatively, you can specify the package name `catkin build <PACKAGE_NAME> --no-deps --catkin-make-args <PROJECT_NAME>_venv_lock`
 
 To migrate a package from catkin_virtualenv <=0.5 to use lock files:
 

--- a/catkin_virtualenv/cmake/catkin_generate_virtualenv.cmake
+++ b/catkin_virtualenv/cmake/catkin_generate_virtualenv.cmake
@@ -141,16 +141,29 @@ function(catkin_generate_virtualenv)
       install/${venv_dir}
   )
 
-  add_custom_target(venv_lock
-    COMMENT "Manually invoked target to generate the lock file on demand"
-    COMMAND ${CATKIN_ENV} rosrun catkin_virtualenv venv_lock ${CMAKE_BINARY_DIR}/${venv_dir}
-      --package-name ${PROJECT_NAME} --input-requirements ${ARG_INPUT_REQUIREMENTS}
-      --extra-pip-args ${processed_pip_args}
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    DEPENDS
-      ${venv_devel_dir}
-      ${CMAKE_SOURCE_DIR}/${ARG_INPUT_REQUIREMENTS}
-  )
+  if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    add_custom_target(venv_lock
+      COMMENT "Manually invoked target to generate the lock file on demand"
+      COMMAND ${CATKIN_ENV} rosrun catkin_virtualenv venv_lock ${CMAKE_BINARY_DIR}/${venv_dir}
+        --package-name ${PROJECT_NAME} --input-requirements ${ARG_INPUT_REQUIREMENTS}
+        --extra-pip-args ${processed_pip_args}
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      DEPENDS
+        ${venv_devel_dir}
+        ${CMAKE_SOURCE_DIR}/${ARG_INPUT_REQUIREMENTS}
+    )
+  else()
+    add_custom_target(${PROJECT_NAME}_venv_lock
+      COMMENT "Manually invoked target to generate the lock file on demand"
+      COMMAND ${CATKIN_ENV} rosrun catkin_virtualenv venv_lock ${CMAKE_BINARY_DIR}/${venv_dir}
+        --package-name ${PROJECT_NAME} --input-requirements ${ARG_INPUT_REQUIREMENTS}
+        --extra-pip-args ${processed_pip_args}
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      DEPENDS
+        ${venv_devel_dir}
+        ${CMAKE_SOURCE_DIR}/${ARG_INPUT_REQUIREMENTS}
+    )
+  endif()
 
   if(NOT package_requirements STREQUAL "" AND (NOT DEFINED ARG_CHECK_VENV OR ARG_CHECK_VENV))
     file(MAKE_DIRECTORY ${CATKIN_TEST_RESULTS_DIR}/${PROJECT_NAME})

--- a/catkin_virtualenv/cmake/catkin_generate_virtualenv.cmake
+++ b/catkin_virtualenv/cmake/catkin_generate_virtualenv.cmake
@@ -141,29 +141,16 @@ function(catkin_generate_virtualenv)
       install/${venv_dir}
   )
 
-  if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-    add_custom_target(venv_lock
-      COMMENT "Manually invoked target to generate the lock file on demand"
-      COMMAND ${CATKIN_ENV} rosrun catkin_virtualenv venv_lock ${CMAKE_BINARY_DIR}/${venv_dir}
-        --package-name ${PROJECT_NAME} --input-requirements ${ARG_INPUT_REQUIREMENTS}
-        --extra-pip-args ${processed_pip_args}
-      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-      DEPENDS
-        ${venv_devel_dir}
-        ${CMAKE_SOURCE_DIR}/${ARG_INPUT_REQUIREMENTS}
-    )
-  else()
-    add_custom_target(${PROJECT_NAME}_venv_lock
-      COMMENT "Manually invoked target to generate the lock file on demand"
-      COMMAND ${CATKIN_ENV} rosrun catkin_virtualenv venv_lock ${CMAKE_BINARY_DIR}/${venv_dir}
-        --package-name ${PROJECT_NAME} --input-requirements ${ARG_INPUT_REQUIREMENTS}
-        --extra-pip-args ${processed_pip_args}
-      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-      DEPENDS
-        ${venv_devel_dir}
-        ${CMAKE_SOURCE_DIR}/${ARG_INPUT_REQUIREMENTS}
-    )
-  endif()
+  add_custom_target(${PROJECT_NAME}_venv_lock
+    COMMENT "Manually invoked target to generate the lock file on demand"
+    COMMAND ${CATKIN_ENV} rosrun catkin_virtualenv venv_lock ${CMAKE_BINARY_DIR}/${venv_dir}
+      --package-name ${PROJECT_NAME} --input-requirements ${ARG_INPUT_REQUIREMENTS}
+      --extra-pip-args ${processed_pip_args}
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    DEPENDS
+      ${venv_devel_dir}
+      ${CMAKE_SOURCE_DIR}/${ARG_INPUT_REQUIREMENTS}
+  )
 
   if(NOT package_requirements STREQUAL "" AND (NOT DEFINED ARG_CHECK_VENV OR ARG_CHECK_VENV))
     file(MAKE_DIRECTORY ${CATKIN_TEST_RESULTS_DIR}/${PROJECT_NAME})


### PR DESCRIPTION
Specifically when `catkin_virtualenv` was used in multiple packages.

---

This should allow people who may use some non-isolated builds (such as `catkin_make` or CLion) to be able to use `catkin_virtualenv` without it grinding to a halt.

I did not adjust the documentation about the name change for the build target in the case of a non-isolated build, since the non-isolated build use case does not seem to be _officially_ supported and I did not want to give the idea that it was. I can adjust the README if desired.