### PR TITLE
Run catkin_run_tests_target only when CATKIN_ENABLE_TESTING is enabled

### DIFF
--- a/catkin_virtualenv/cmake/catkin_generate_virtualenv.cmake
+++ b/catkin_virtualenv/cmake/catkin_generate_virtualenv.cmake
@@ -152,7 +152,7 @@ function(catkin_generate_virtualenv)
       ${PROJECT_SOURCE_DIR}/${ARG_INPUT_REQUIREMENTS}
   )
 
-  if(NOT package_requirements STREQUAL "" AND (NOT DEFINED ARG_CHECK_VENV OR ARG_CHECK_VENV))
+  if(CATKIN_ENABLE_TESTING AND NOT package_requirements STREQUAL "" AND (NOT DEFINED ARG_CHECK_VENV OR ARG_CHECK_VENV))
     file(MAKE_DIRECTORY ${CATKIN_TEST_RESULTS_DIR}/${PROJECT_NAME})
     catkin_run_tests_target("venv_check" "${PROJECT_NAME}-requirements" "venv_check-${PROJECT_NAME}-requirements.xml"
       COMMAND "${CATKIN_ENV} rosrun catkin_virtualenv venv_check ${venv_dir} --requirements ${package_requirements} \


### PR DESCRIPTION
# What is this?

At current, if I do a catkin build with `CATKIN_ENABLE_TESTING=FALSE`, I get the following error when calling `catkin_generate_virtualenv`.

```
Unknown CMake command "catkin_run_tests_target"
```

This is because it is not defined when `CATKIN_ENABLE_TESTING=FALSE`.

