### PR TITLE
Use upstream function to configure logging

### DIFF
--- a/catkin_virtualenv/src/catkin_virtualenv/__init__.py
+++ b/catkin_virtualenv/src/catkin_virtualenv/__init__.py
@@ -18,21 +18,14 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-import logging.config
-import os
 import subprocess
-import yaml
+import rosgraph.roslogging
 
 logger = logging.getLogger(__name__)
 
 
 def configure_logging():
-    try:
-        with open(os.environ["ROS_PYTHON_LOG_CONFIG_FILE"]) as config:
-            logging.config.dictConfig(yaml.safe_load(config))
-    except KeyError:
-        logging.basicConfig()
-
+    rosgraph.roslogging.configure_logging('catkin_virtualenv')
     return logging.getLogger()
 
 


### PR DESCRIPTION
The config file for logging is assumed either `.conf` file or `.yaml` file (i.e. `/opt/ros/noetic/etc/ros/python_logging.conf`) in ROS ecosystem, but currently only `.yaml` file is supported in this package.
This PR changes the `configure_logging` function defined in `__init__.py` to use the existing function to configure logging feature not to differentiate the behavior of loading logging config files.
https://github.com/ros/ros_comm/blob/noetic-devel/tools/rosgraph/src/rosgraph/roslogging.py#L167