### PR TITLE
Import setup from setuptools instead of distutils.core

### DIFF
--- a/catkin_virtualenv/package.xml
+++ b/catkin_virtualenv/package.xml
@@ -30,6 +30,8 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
   <author email="pbovbel@locusrobotics.com">Paul Bovbel</author>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <build_export_depend>python3-dev</build_export_depend>
   <build_export_depend>python3-nose</build_export_depend>

--- a/catkin_virtualenv/package.xml
+++ b/catkin_virtualenv/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <!--
 Software License Agreement (GPL)
 
@@ -20,7 +20,7 @@ General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program. If not, see <http://www.gnu.org/licenses/>.
 -->
-<package format="2">
+<package format="3">
   <name>catkin_virtualenv</name>
   <version>0.9.0</version>
   <description>Bundle python requirements in a catkin package via virtualenv.</description>

--- a/catkin_virtualenv/setup.py
+++ b/catkin_virtualenv/setup.py
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(packages=["catkin_virtualenv"], package_dir={"": "src"})


### PR DESCRIPTION
Recently users of newer distributions who build Noetic from source noticed issues when importing setup from distutils.core.
This problem was discussed on [Discourse](https://discourse.ros.org/t/ros-1-and-python-3-10s-deprecation-of-distutils-core/29834), and we hope that we can make the needed updates to Noetic to allow for future builds from source of Noetic.
As a first step, this PR introduces changes from the [Noetic Migration Guide](https://wiki.ros.org/noetic/Migration#Setuptools_instead_of_Distutils) that addresses the change to the setuptools module instead of distutils.core and the corresponding buildtool_depend tags for python 2&3.