### PR TITLE
Ignore order in requirements consistency check

### DIFF
--- a/catkin_virtualenv/src/catkin_virtualenv/venv.py
+++ b/catkin_virtualenv/src/catkin_virtualenv/venv.py
@@ -128,6 +128,8 @@ class Virtualenv:
             content = content.lower()
             # Split into lines for diff
             content = content.splitlines()
+            # ignore order
+            content.sort()
             return content
 
         # Compare against existing requirements


### PR DESCRIPTION
This should avoid false positives for the locked venv check