### PR TITLE
Testing with pip cache purge prior to install pip packages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ tailorTestPipeline(
   // Release label to pull test images from.
   release_label: 'hotdog',
   // OS distributions to test.
-  distributions: ['focal', 'jammy'],
+  distributions: ['jammy'],
   // Version of tailor_meta to build against
   tailor_meta: '0.1.24',
   // Master or release branch associated with this track

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-@Library('tailor-meta@0.1.21')_
+@Library('tailor-meta@0.1.23')_
 tailorTestPipeline(
   // Name of job that generated this test definition.
   rosdistro_job: '/ci/rosdistro/master',
@@ -12,7 +12,7 @@ tailorTestPipeline(
   // OS distributions to test.
   distributions: ['focal', 'jammy'],
   // Version of tailor_meta to build against
-  tailor_meta: '0.1.21',
+  tailor_meta: '0.1.23',
   // Master or release branch associated with this track
   source_branch: 'test_pip_cache_purge',
   // Docker registry where test image is stored

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-@Library('tailor-meta@0.1.23')_
+@Library('tailor-meta@0.1.24')_
 tailorTestPipeline(
   // Name of job that generated this test definition.
   rosdistro_job: '/ci/rosdistro/master',
@@ -12,7 +12,7 @@ tailorTestPipeline(
   // OS distributions to test.
   distributions: ['focal', 'jammy'],
   // Version of tailor_meta to build against
-  tailor_meta: '0.1.23',
+  tailor_meta: '0.1.24',
   // Master or release branch associated with this track
   source_branch: 'test_pip_cache_purge',
   // Docker registry where test image is stored

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ tailorTestPipeline(
   // Version of tailor_meta to build against
   tailor_meta: '0.1.21',
   // Master or release branch associated with this track
-  source_branch: 'master',
+  source_branch: 'test_pip_cache_purge',
   // Docker registry where test image is stored
   docker_registry: 'https://084758475884.dkr.ecr.us-east-1.amazonaws.com/locus-tailor'
 )

--- a/catkin_virtualenv/src/catkin_virtualenv/venv.py
+++ b/catkin_virtualenv/src/catkin_virtualenv/venv.py
@@ -102,8 +102,10 @@ class Virtualenv:
             get_pip_path, _ = urlretrieve("https://bootstrap.pypa.io/pip/get-pip.py")
             run_command([self._venv_bin("python"), get_pip_path], check=True)
 
+        #(gservin): test --no-cache-dir
         run_command(
-            [self._venv_bin("python"), "-m", "pip", "install", "-vvv"] + extra_pip_args + preinstall, check=True
+            [self._venv_bin("python"), "-m", "pip", "install", "--no-cache-dir", "-vvv"] + extra_pip_args + preinstall,
+            check=True
         )
 
     def install(self, requirements, extra_pip_args):

--- a/catkin_virtualenv/src/catkin_virtualenv/venv.py
+++ b/catkin_virtualenv/src/catkin_virtualenv/venv.py
@@ -109,10 +109,10 @@ class Virtualenv:
     def install(self, requirements, extra_pip_args):
         """Purge the cache first before installing."""  # (KLAD) testing to debug an issue on build farm
         command = [self._venv_bin("python"), "-m", "pip", "cache", "purge"]
-        """ Sync a virtualenv with the specified requirements. """
+        """ Sync a virtualenv with the specified requirements."""
         command = [self._venv_bin("python"), "-m", "pip", "install", "-vvv"] + extra_pip_args
         for req in requirements:
-            run_command(command + ["-r", req], check=True)
+            run_command(command + ["-r", req] + "--no-cache-dir", check=True)  # (klad) test nocachedir
 
     def check(self, requirements, extra_pip_args):
         """Check if a set of requirements is completely locked."""

--- a/catkin_virtualenv/src/catkin_virtualenv/venv.py
+++ b/catkin_virtualenv/src/catkin_virtualenv/venv.py
@@ -101,7 +101,7 @@ class Virtualenv:
             get_pip_path, _ = urlretrieve("https://bootstrap.pypa.io/pip/get-pip.py")
             run_command([self._venv_bin("python"), get_pip_path], check=True)
 
-        run_command([self._venv_bin("python"), "-m", "pip", "install", -"vvv"] + extra_pip_args + preinstall, check=True)
+        run_command([self._venv_bin("python"), "-m", "pip", "install", "-vvv"] + extra_pip_args + preinstall, check=True)
 
     def install(self, requirements, extra_pip_args):
         """ Purge the cache first before installing. """ # (KLAD) testing to debug an issue on build farm

--- a/catkin_virtualenv/src/catkin_virtualenv/venv.py
+++ b/catkin_virtualenv/src/catkin_virtualenv/venv.py
@@ -66,7 +66,7 @@ class Virtualenv:
             raise RuntimeError(error_msg)
 
         preinstall = [
-            "pip==22.0.2",
+            "pip==22.2.2",
             "pip-tools==6.10.0",
         ]
 

--- a/catkin_virtualenv/src/catkin_virtualenv/venv.py
+++ b/catkin_virtualenv/src/catkin_virtualenv/venv.py
@@ -102,16 +102,16 @@ class Virtualenv:
             get_pip_path, _ = urlretrieve("https://bootstrap.pypa.io/pip/get-pip.py")
             run_command([self._venv_bin("python"), get_pip_path], check=True)
 
-        #(gservin): test --no-cache-dir
+        # (gservin): test --no-cache-dir
         run_command(
             [self._venv_bin("python"), "-m", "pip", "install", "--no-cache-dir", "-vvv"] + extra_pip_args + preinstall,
-            check=True
+            check=True,
         )
 
     def install(self, requirements, extra_pip_args):
         """Purge the cache first before installing."""  # (KLAD) testing to debug an issue on build farm
         command = [self._venv_bin("python"), "-m", "pip", "cache", "purge"]
-        """ Sync a virtualenv with the specified requirements.""" #(KLAD) testing no-cache-dir
+        """ Sync a virtualenv with the specified requirements."""  # (KLAD) testing no-cache-dir
         command = [self._venv_bin("python"), "-m", "pip", "install", "-vvv", "--no-cache-dir"] + extra_pip_args
         for req in requirements:
             run_command(command + ["-r", req], check=True)

--- a/catkin_virtualenv/src/catkin_virtualenv/venv.py
+++ b/catkin_virtualenv/src/catkin_virtualenv/venv.py
@@ -101,13 +101,13 @@ class Virtualenv:
             get_pip_path, _ = urlretrieve("https://bootstrap.pypa.io/pip/get-pip.py")
             run_command([self._venv_bin("python"), get_pip_path], check=True)
 
-        run_command([self._venv_bin("python"), "-m", "-vvv", "pip", "install"] + extra_pip_args + preinstall, check=True)
+        run_command([self._venv_bin("python"), "-m", "pip", "install", -"vvv"] + extra_pip_args + preinstall, check=True)
 
     def install(self, requirements, extra_pip_args):
         """ Purge the cache first before installing. """ # (KLAD) testing to debug an issue on build farm
         command = [self._venv_bin("python"), "-m", "pip", "cache", "purge"] 
         """ Sync a virtualenv with the specified requirements. """
-        command = [self._venv_bin("python"), "-m", "-vvv", "pip", "install"] + extra_pip_args
+        command = [self._venv_bin("python"), "-m", "pip", "install", "-vvv"] + extra_pip_args
         for req in requirements:
             run_command(command + ["-r", req], check=True)
 

--- a/catkin_virtualenv/src/catkin_virtualenv/venv.py
+++ b/catkin_virtualenv/src/catkin_virtualenv/venv.py
@@ -109,10 +109,10 @@ class Virtualenv:
     def install(self, requirements, extra_pip_args):
         """Purge the cache first before installing."""  # (KLAD) testing to debug an issue on build farm
         command = [self._venv_bin("python"), "-m", "pip", "cache", "purge"]
-        """ Sync a virtualenv with the specified requirements."""
-        command = [self._venv_bin("python"), "-m", "pip", "install", "-vvv"] + extra_pip_args
+        """ Sync a virtualenv with the specified requirements.""" #(KLAD) testing no-cache-dir
+        command = [self._venv_bin("python"), "-m", "pip", "install", "-vvv", "--no-cache-dir"] + extra_pip_args
         for req in requirements:
-            run_command(command + ["-r", req] + "--no-cache-dir", check=True)  # (klad) test nocachedir
+            run_command(command + ["-r", req], check=True)
 
     def check(self, requirements, extra_pip_args):
         """Check if a set of requirements is completely locked."""

--- a/catkin_virtualenv/src/catkin_virtualenv/venv.py
+++ b/catkin_virtualenv/src/catkin_virtualenv/venv.py
@@ -101,13 +101,13 @@ class Virtualenv:
             get_pip_path, _ = urlretrieve("https://bootstrap.pypa.io/pip/get-pip.py")
             run_command([self._venv_bin("python"), get_pip_path], check=True)
 
-        run_command([self._venv_bin("python"), "-m", "pip", "install"] + extra_pip_args + preinstall, check=True)
+        run_command([self._venv_bin("python"), "-m", "-vvv", "pip", "install"] + extra_pip_args + preinstall, check=True)
 
     def install(self, requirements, extra_pip_args):
         """ Purge the cache first before installing. """ # (KLAD) testing to debug an issue on build farm
         command = [self._venv_bin("python"), "-m", "pip", "cache", "purge"] 
         """ Sync a virtualenv with the specified requirements. """
-        command = [self._venv_bin("python"), "-m", "pip", "install"] + extra_pip_args
+        command = [self._venv_bin("python"), "-m", "-vvv", "pip", "install"] + extra_pip_args
         for req in requirements:
             run_command(command + ["-r", req], check=True)
 

--- a/catkin_virtualenv/src/catkin_virtualenv/venv.py
+++ b/catkin_virtualenv/src/catkin_virtualenv/venv.py
@@ -104,6 +104,8 @@ class Virtualenv:
         run_command([self._venv_bin("python"), "-m", "pip", "install"] + extra_pip_args + preinstall, check=True)
 
     def install(self, requirements, extra_pip_args):
+        """ Purge the cache first before installing. """ # (KLAD) testing to debug an issue on build farm
+        command = [self._venv_bin("python"), "-m", "pip", "cache", "purge"] 
         """ Sync a virtualenv with the specified requirements. """
         command = [self._venv_bin("python"), "-m", "pip", "install"] + extra_pip_args
         for req in requirements:

--- a/catkin_virtualenv/src/catkin_virtualenv/venv.py
+++ b/catkin_virtualenv/src/catkin_virtualenv/venv.py
@@ -26,6 +26,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+
 try:
     from urllib.request import urlretrieve
 except ImportError:
@@ -45,11 +46,11 @@ logger = logging.getLogger(__name__)
 
 class Virtualenv:
     def __init__(self, path):
-        """ Manage a virtualenv at the specified path. """
+        """Manage a virtualenv at the specified path."""
         self.path = path
 
     def initialize(self, python, use_system_packages, extra_pip_args, clean=True):
-        """ Initialize a new virtualenv using the specified python version and extra arguments. """
+        """Initialize a new virtualenv using the specified python version and extra arguments."""
         if clean:
             try:
                 shutil.rmtree(self.path)
@@ -83,7 +84,7 @@ class Virtualenv:
 
         without_pip = self._check_module(system_python, "ensurepip") is False
         if without_pip:
-            virtualenv.append('--without-pip')
+            virtualenv.append("--without-pip")
 
         virtualenv.append(self.path)
         run_command(virtualenv, check=True)
@@ -91,28 +92,30 @@ class Virtualenv:
         if without_pip:
             # install pip via get-pip.py
             version_proc = run_command(
-                ['python', "-cimport sys; print('{}.{}'.format(*sys.version_info))"],
-                capture_output=True)
+                ["python", "-cimport sys; print('{}.{}'.format(*sys.version_info))"], capture_output=True
+            )
             version = version_proc.stdout
             if isinstance(version, bytes):
-                version = version.decode('utf-8')
+                version = version.decode("utf-8")
             version = version.strip()
             # download pip from https://bootstrap.pypa.io/pip/
             get_pip_path, _ = urlretrieve("https://bootstrap.pypa.io/pip/get-pip.py")
             run_command([self._venv_bin("python"), get_pip_path], check=True)
 
-        run_command([self._venv_bin("python"), "-m", "pip", "install", "-vvv"] + extra_pip_args + preinstall, check=True)
+        run_command(
+            [self._venv_bin("python"), "-m", "pip", "install", "-vvv"] + extra_pip_args + preinstall, check=True
+        )
 
     def install(self, requirements, extra_pip_args):
-        """ Purge the cache first before installing. """ # (KLAD) testing to debug an issue on build farm
-        command = [self._venv_bin("python"), "-m", "pip", "cache", "purge"] 
+        """Purge the cache first before installing."""  # (KLAD) testing to debug an issue on build farm
+        command = [self._venv_bin("python"), "-m", "pip", "cache", "purge"]
         """ Sync a virtualenv with the specified requirements. """
         command = [self._venv_bin("python"), "-m", "pip", "install", "-vvv"] + extra_pip_args
         for req in requirements:
             run_command(command + ["-r", req], check=True)
 
     def check(self, requirements, extra_pip_args):
-        """ Check if a set of requirements is completely locked. """
+        """Check if a set of requirements is completely locked."""
         with open(requirements, "r") as f:
             existing_requirements = f.read()
 
@@ -140,7 +143,7 @@ class Virtualenv:
         return diff
 
     def lock(self, package_name, input_requirements, no_overwrite, extra_pip_args):
-        """ Create a frozen requirement set from a set of input specifications. """
+        """Create a frozen requirement set from a set of input specifications."""
         try:
             output_requirements = collect_requirements(package_name, no_deps=True)[0]
         except IndexError:
@@ -171,7 +174,7 @@ class Virtualenv:
         logger.info("Wrote new lock file to {}".format(output_requirements))
 
     def relocate(self, target_dir):
-        """ Relocate a virtualenv to another directory. """
+        """Relocate a virtualenv to another directory."""
         self._delete_bytecode()
         relocate.fix_shebangs(self.path, target_dir)
         relocate.fix_activate_path(self.path, target_dir)
@@ -199,7 +202,7 @@ class Virtualenv:
             return False
 
     def _delete_bytecode(self):
-        """ Remove all .py[co] files since they embed absolute paths. """
+        """Remove all .py[co] files since they embed absolute paths."""
         for root, _, files in os.walk(self.path):
             for f in files:
                 if _BYTECODE_REGEX.match(f):


### PR DESCRIPTION
The following is a test to see if clearing the pip cache prevents the weird situation where pip cannot install a package based on requirements.txt. There are instances when a package on the build farm will fail due to venv not being able to pip install the package, even though it exists in pypi. 

In #1 discusses about how pip will often use locally built cached wheels first and how by default pip will use local caching first. Perhaps this could be where there is an issue. 

[1] https://pip.pypa.io/en/stable/topics/caching/