### PR TITLE
Remove old unused version check that depends on a binary named python

### DIFF
--- a/catkin_virtualenv/src/catkin_virtualenv/venv.py
+++ b/catkin_virtualenv/src/catkin_virtualenv/venv.py
@@ -90,14 +90,6 @@ class Virtualenv:
         run_command(virtualenv, check=True)
 
         if without_pip:
-            # install pip via get-pip.py
-            version_proc = run_command(
-                ["python", "-cimport sys; print('{}.{}'.format(*sys.version_info))"], capture_output=True
-            )
-            version = version_proc.stdout
-            if isinstance(version, bytes):
-                version = version.decode("utf-8")
-            version = version.strip()
             # download pip from https://bootstrap.pypa.io/pip/
             get_pip_path, _ = urlretrieve("https://bootstrap.pypa.io/pip/get-pip.py")
             run_command([self._venv_bin("python"), get_pip_path], check=True)


### PR DESCRIPTION
The `version` variable set here is not used (anymore?).

The `run_command()` failed for me in Ubuntu 22.04 because there is no executable named `python`, only `python3` (without package `python-is-python3` installed).