### PR TITLE
RST-12669 Use program basename instead of full path

### DIFF
--- a/catkin_virtualenv/cmake/templates/program.devel.in
+++ b/catkin_virtualenv/cmake/templates/program.devel.in
@@ -8,7 +8,7 @@ if [ "${ARG_RENAME_PROCESS}" = "TRUE" ]; then
 	from setproctitle import setproctitle
 
 	program_path = "${program_path}"
-	setproctitle(' '.join([program_path] + sys.argv[1:]))
+	setproctitle(' '.join(["${program_basename}"] + sys.argv[1:]))
 	exec(open(program_path).read())
 	EOF
 else

--- a/catkin_virtualenv/cmake/templates/program.install.in
+++ b/catkin_virtualenv/cmake/templates/program.install.in
@@ -8,7 +8,7 @@ if [ "${ARG_RENAME_PROCESS}" = "TRUE" ]; then
 	from setproctitle import setproctitle
 
 	program_path = "${CMAKE_INSTALL_PREFIX}/${program_install_location}/${program_basename}"
-	setproctitle(' '.join([program_path] + sys.argv[1:]))
+	setproctitle(' '.join(["${program_basename}"] + sys.argv[1:]))
 	exec(open(program_path).read())
 	EOF
 else


### PR DESCRIPTION
While testing https://github.com/locusrobotics/locus_common/pull/289, I noticed that in telegraf all caktin_virtualenv-related processes are being renamed to `/opt/locusrobot`, the truncated program path. The full path was fine for ELK stack and friends, but in the new metrics world we should use the program basename.

A note that https://pypi.org/project/setproctitle/ is different than BSD's setproctitle, in that it calls prctl under the hood, and somehow clobbers cmdline as well.