### PR TITLE
Allow python3.12

### DIFF
--- a/catkin_virtualenv/src/catkin_virtualenv/venv.py
+++ b/catkin_virtualenv/src/catkin_virtualenv/venv.py
@@ -84,8 +84,11 @@ class Virtualenv:
             virtualenv = ["virtualenv", "--no-setuptools", "--verbose", "--python", python]
             # py2's virtualenv command will try install latest setuptools. setuptools>=45 not compatible with py2,
             # but we do require a reasonably up-to-date version (because of pip==20.1), so v44 at least.
-            if python_version < (3, 12):
+            # For Python 3.x (< 3.12), setuptools is not yet pinned in preinstall but is needed.
+            if python_version < (3, 0):
                 preinstall += ["setuptools>=44,<45"]
+            elif python_version < (3, 12):
+                preinstall += ["setuptools"]
 
         if use_system_packages:
             virtualenv.append("--system-site-packages")
@@ -213,11 +216,15 @@ class Virtualenv:
 
     def _get_python_version(self, python_executable):
         result = run_command(
-            [python_executable, "-c", "import sys; print(sys.version_info.major, sys.version_info.minor)"],
+            [python_executable, "-c",
+             "import sys; sys.stdout.write('%s %s\\n' % (sys.version_info[0], sys.version_info[1]))"],
             capture_output=True,
             check=True,
         )
-        major, minor = result.stdout.decode().strip().split()
+        stdout = result.stdout
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode("utf-8")
+        major, minor = stdout.strip().split()
         return (int(major), int(minor))
 
     def _check_module(self, python_executable, module):

--- a/catkin_virtualenv/src/catkin_virtualenv/venv.py
+++ b/catkin_virtualenv/src/catkin_virtualenv/venv.py
@@ -64,10 +64,18 @@ class Virtualenv:
                 error_msg += " Perhaps you meant python{}".format(python)
             raise RuntimeError(error_msg)
 
-        preinstall = [
-            "pip==24.0",
-            "pip-tools==7.4.1",
-        ]
+        python_version = self._get_python_version(system_python)
+        if python_version >= (3, 12):
+            preinstall = [
+                "pip==26.0.1",
+                "pip-tools==7.5.3",
+                "setuptools==82.0.0",
+            ]
+        else:
+            preinstall = [
+                "pip==24.0",
+                "pip-tools==7.4.1",
+            ]
 
         builtin_venv = self._check_module(system_python, "venv")
         if builtin_venv:
@@ -76,7 +84,8 @@ class Virtualenv:
             virtualenv = ["virtualenv", "--no-setuptools", "--verbose", "--python", python]
             # py2's virtualenv command will try install latest setuptools. setuptools>=45 not compatible with py2,
             # but we do require a reasonably up-to-date version (because of pip==20.1), so v44 at least.
-            preinstall += ["setuptools>=44,<45"]
+            if python_version < (3, 12):
+                preinstall += ["setuptools>=44,<45"]
 
         if use_system_packages:
             virtualenv.append("--system-site-packages")
@@ -201,6 +210,15 @@ class Virtualenv:
             if global_pip_compile is None:
                 raise RuntimeError("pip-compile not found found in Venv or global PATH") from exc
             return global_pip_compile
+
+    def _get_python_version(self, python_executable):
+        result = run_command(
+            [python_executable, "-c", "import sys; print(sys.version_info.major, sys.version_info.minor)"],
+            capture_output=True,
+            check=True,
+        )
+        major, minor = result.stdout.decode().strip().split()
+        return (int(major), int(minor))
 
     def _check_module(self, python_executable, module):
         try:


### PR DESCRIPTION
Without these fixes, we get
```
Traceback (most recent call last):
  File "/usr/local/bin/catkin", line 5, in <module>
    from catkin_tools.commands.catkin import main
  File "/opt/locusrobotics/virtualenv/catkin-tools/lib/python3.12/site-packages/catkin_tools/commands/catkin.py", line 21, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```
 when trying to run on noble. These changes seem to work fine on jammy as well