### PR TITLE
Reduce logging level

### DIFF
--- a/catkin_virtualenv/src/catkin_virtualenv/__init__.py
+++ b/catkin_virtualenv/src/catkin_virtualenv/__init__.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 def configure_logging():
     logging.basicConfig(
-        level=logging.WARN,
+        level=logging.WARNING,
         format='[%(levelname)s] [%(name)s]: %(message)s'
     )
     return logging.getLogger()

--- a/catkin_virtualenv/src/catkin_virtualenv/__init__.py
+++ b/catkin_virtualenv/src/catkin_virtualenv/__init__.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 def configure_logging():
     logging.basicConfig(
-        level=logging.INFO,
+        level=logging.WARN,
         format='[%(levelname)s] [%(name)s]: %(message)s'
     )
     return logging.getLogger()


### PR DESCRIPTION
Addresses https://github.com/locusrobotics/catkin_virtualenv/pull/123#discussion_r3058510062

Removes the excessive logging
```
INFO] [catkin_virtualenv]: grep -l -r -e ^#!.*bin/\(env \)\?\(python\|pypy\|ipy\|jython\) -e ^'''exec.*bin/\(python\|pypy\|ipy\|jython\) /home/aravindran/locus_dev/hotdog/devel/.private/nav_engine_scripts/share/nav_engine_scripts/venv/bin
[INFO] [catkin_virtualenv]: sed -i s-^#!.*bin/\(env \)\?\(python\|pypy\|ipy\|jython\)\"\?-#!/home/aravindran/locus_dev/hotdog/devel/\.private/nav_engine_scripts/share/nav_engine_scripts/venv/bin/python-;s-^'''exec'.*bin/\(python\|pypy\|ipy\|jython\)-'''exec' /home/aravindran/locus_dev/hotdog/devel/\.private/nav_engine_scripts/share/nav_engine_scripts/venv/bin/python- /home/aravindran/locus_dev/hotdog/devel/.private/nav_engine_scripts/share/nav_engine_scripts/venv/bin/distro
[INFO] [catkin_virtualenv]: sed -i s-^#!.*bin/\(env \)\?\(python\|pypy\|ipy\|jython\)\"\?-#!/home/aravindran/locus_dev/hotdog/devel/\.private/nav_engine_scripts/share/nav_engine_scripts/venv/bin/python-;s-^'''exec'.*bin/\(python\|pypy\|ipy\|jython\)-'''exec' 
...
```